### PR TITLE
Remove unnecessary LoI section element

### DIFF
--- a/src/epub/text/loi.xhtml
+++ b/src/epub/text/loi.xhtml
@@ -6,42 +6,40 @@
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 	</head>
 	<body epub:type="backmatter">
-		<section id="loi" epub:type="loi">
-			<nav epub:type="loi">
-				<h2 epub:type="title">List of Illustrations</h2>
-				<ol>
-					<li>
-						<p>
-							<a href="chapter-1-1.xhtml#illustration-1">A straight line sloping upwards to the right at an approximately 10 degree angle.</a>
-						</p>
-					</li>
-					<li>
-						<p>
-							<a href="chapter-1-1.xhtml#illustration-2">A line rising upwards to the right in a series of three shallow steps.</a>
-						</p>
-					</li>
-					<li>
-						<p>
-							<a href="chapter-1-1.xhtml#illustration-3">A straight line sloping upwards to the right at an approximately 23 degree angle.</a>
-						</p>
-					</li>
-					<li>
-						<p>
-							<a href="chapter-1-1.xhtml#illustration-4">An almost exactly vertical line tilted very slightly to the right at the top.</a>
-						</p>
-					</li>
-					<li>
-						<p>
-							<a href="chapter-1-1.xhtml#illustration-5">A line rising upwards to the right in a series of three shallow steps, the top of each step curving slightly in a vertical direction.</a>
-						</p>
-					</li>
-					<li>
-						<p>
-							<a href="chapter-1-1.xhtml#illustration-6">A roughly-shaped line which at first rises to the right in a series of shallow steps but after reaching an apex curves strongly downward to the right to reach a level with its starting point.</a>
-						</p>
-					</li>
-				</ol>
-			</nav>
-		</section>
+		<nav id="loi" epub:type="loi">
+			<h2 epub:type="title">List of Illustrations</h2>
+			<ol>
+				<li>
+					<p>
+						<a href="chapter-1-1.xhtml#illustration-1">A straight line sloping upwards to the right at an approximately 10 degree angle.</a>
+					</p>
+				</li>
+				<li>
+					<p>
+						<a href="chapter-1-1.xhtml#illustration-2">A line rising upwards to the right in a series of three shallow steps.</a>
+					</p>
+				</li>
+				<li>
+					<p>
+						<a href="chapter-1-1.xhtml#illustration-3">A straight line sloping upwards to the right at an approximately 23 degree angle.</a>
+					</p>
+				</li>
+				<li>
+					<p>
+						<a href="chapter-1-1.xhtml#illustration-4">An almost exactly vertical line tilted very slightly to the right at the top.</a>
+					</p>
+				</li>
+				<li>
+					<p>
+						<a href="chapter-1-1.xhtml#illustration-5">A line rising upwards to the right in a series of three shallow steps, the top of each step curving slightly in a vertical direction.</a>
+					</p>
+				</li>
+				<li>
+					<p>
+						<a href="chapter-1-1.xhtml#illustration-6">A roughly-shaped line which at first rises to the right in a series of shallow steps but after reaching an apex curves strongly downward to the right to reach a level with its starting point.</a>
+					</p>
+				</li>
+			</ol>
+		</nav>
 	</body>
 </html>


### PR DESCRIPTION
Per https://standardebooks.org/manual/1.8.0/7-high-level-structural-patterns#7.9 the `<nav>` should be directly nested under the `<body>`.